### PR TITLE
Update crawler for python 3 issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+beautifulsoup4==4.5.1


### PR DESCRIPTION
I had some issues running the crawler with python 3.4.5 about urllib modules not being defined as well as some issues with some of the APIs. Not sure if it's just me, but wanted to share my fixes.

I also included a `requirements.txt` because it's not obvious when dependencies are needed beyond the core python libs.
